### PR TITLE
Fix #399: url validation should fail when valid URL is only a substring

### DIFF
--- a/spec/url-rule.js
+++ b/spec/url-rule.js
@@ -35,4 +35,10 @@ describe("url validation rule", function() {
     const validator = new Validator({}, { link: "url" });
     expect(validator.passes()).to.be.true;
   });
+
+  it("should fail if invalid strings precede the valid URL", function() {
+    const link = '==sdkdhttps://t.co/abc.jpg';
+    const validator = new Validator({ link: link }, { link: "url" });
+    expect(validator.passes()).to.be.false;
+  });
 });

--- a/src/rules.js
+++ b/src/rules.js
@@ -257,7 +257,7 @@ var rules = {
   },
 
   url: function (url) {
-    return /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/i.test(url);
+    return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/i.test(url);
   },
 
   alpha: function (val) {


### PR DESCRIPTION
# Fixes:
https://github.com/mikeerickson/validatorjs/issues/399