### PR TITLE
Pass req and attribute to required rule

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -116,7 +116,7 @@ var rules = {
   required_if: function (val, req, attribute) {
     req = this.getParameters();
     if (this.validator._objectPath(this.validator.input, req[0]) === req[1]) {
-      return this.validator.getRule("required").validate(val);
+      return this.validator.getRule("required").validate(val, req, attribute);
     }
 
     return true;
@@ -125,7 +125,7 @@ var rules = {
   required_unless: function (val, req, attribute) {
     req = this.getParameters();
     if (this.validator._objectPath(this.validator.input, req[0]) !== req[1]) {
-      return this.validator.getRule("required").validate(val);
+      return this.validator.getRule("required").validate(val, req, attribute);
     }
 
     return true;
@@ -133,7 +133,7 @@ var rules = {
 
   required_with: function (val, req, attribute) {
     if (this.validator._objectPath(this.validator.input, req)) {
-      return this.validator.getRule("required").validate(val);
+      return this.validator.getRule("required").validate(val, req, attribute);
     }
 
     return true;
@@ -148,7 +148,7 @@ var rules = {
       }
     }
 
-    return this.validator.getRule("required").validate(val);
+    return this.validator.getRule("required").validate(val, req, attribute);
   },
 
   required_without: function (val, req, attribute) {
@@ -156,7 +156,7 @@ var rules = {
       return true;
     }
 
-    return this.validator.getRule("required").validate(val);
+    return this.validator.getRule("required").validate(val, req, attribute);
   },
 
   required_without_all: function (val, req, attribute) {
@@ -168,7 +168,7 @@ var rules = {
       }
     }
 
-    return this.validator.getRule("required").validate(val);
+    return this.validator.getRule("required").validate(val, req, attribute);
   },
 
   boolean: function (val) {


### PR DESCRIPTION
When registering a custom "required" rule to replace the default rule, the replacement may need additional context other than just the value to determine if a field is required, but currently only the value is passed to the required rule.  By just changing the calls to the required rule in the various other required rule variants to pass req and attribute, this fixes the issue.

Background: I'm using validatorjs in a situation where the UI is configurable and also can change dynamically as the user interacts with it.  Specifically, form elements can become visible or editable or not visible or editable dynamically as the user interacts with other fields.  Also, I have a specific check for a field that is a dropdown but for which there are no options available to choose from (due to incorrect configuration).  In order to accomplish these things, I've registered a custom "required" rule that replaces the default required rule.  When other required rules such as "required_with" call required, they thus call my custom rule, and this custom rule needs to know the attribute in order to perform the dynamic checks previously listed.