### PR TITLE
Pass req and attribute to required rule

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -116,7 +116,7 @@ var rules = {
   required_if: function (val, req, attribute) {
     req = this.getParameters();
     if (this.validator._objectPath(this.validator.input, req[0]) === req[1]) {
-      return this.validator.getRule("required").validate(val);
+      return this.validator.getRule("required").validate(val, req, attribute);
     }
 
     return true;
@@ -125,7 +125,7 @@ var rules = {
   required_unless: function (val, req, attribute) {
     req = this.getParameters();
     if (this.validator._objectPath(this.validator.input, req[0]) !== req[1]) {
-      return this.validator.getRule("required").validate(val);
+      return this.validator.getRule("required").validate(val, req, attribute);
     }
 
     return true;
@@ -133,7 +133,7 @@ var rules = {
 
   required_with: function (val, req, attribute) {
     if (this.validator._objectPath(this.validator.input, req)) {
-      return this.validator.getRule("required").validate(val);
+      return this.validator.getRule("required").validate(val, req, attribute);
     }
 
     return true;
@@ -148,7 +148,7 @@ var rules = {
       }
     }
 
-    return this.validator.getRule("required").validate(val);
+    return this.validator.getRule("required").validate(val, req, attribute);
   },
 
   required_without: function (val, req, attribute) {
@@ -156,7 +156,7 @@ var rules = {
       return true;
     }
 
-    return this.validator.getRule("required").validate(val);
+    return this.validator.getRule("required").validate(val, req, attribute);
   },
 
   required_without_all: function (val, req, attribute) {
@@ -168,7 +168,7 @@ var rules = {
       }
     }
 
-    return this.validator.getRule("required").validate(val);
+    return this.validator.getRule("required").validate(val, req, attribute);
   },
 
   boolean: function (val) {


### PR DESCRIPTION
It's possible to replace the "required" rule with a custom rule.  That custom rule may need additional context other than just the field value to work, but the various required rules that depend on the required rule only pass in the value.  Changing those other required rules to pass all three attributes (value, req, and attribute) to the required rule.

Background: I have a custom required rule for a configuration-driven dynamic UI wherein fields may become visible or not or may be editable or not.  Also my required rule checks if a field is a dropdown and has no options (due to misconfiguration), making it not required since the user would be stuck in a situation they could not resolve.  My custom required rule requires the attribute in order to look the field up in the dynamic configuration, but when the required derivative rules call the required rule, they only pass the value and not the req or attribute parameters.  Simply adding those parameters in when calling the base required rule fixes the problem for me.