### PR TITLE
fix: checkFalsePositiveDate(dateString = '') breaks IE (#404)

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -4,8 +4,8 @@ function leapYear(year) {
   return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 }
 
-function checkFalsePositiveDates(dateString = '') {
-
+function checkFalsePositiveDates(dateString) {
+  let dateString = dateString || '';
   if (dateString.length === 10) {
 
     // massage input to use yyyy-mm-dd format


### PR DESCRIPTION
#404 bugfix, when default parameter IE 11 was broken