### PR TITLE
feat: access of input value on template string for error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ __name__ {String} - The name of the rule.
 
 __callbackFn__ {Function} - Returns a boolean to represent a successful or failed validation.
 
-__errorMessage__ {String} - An optional string where you can specify a custom error message. _:attribute_ inside errorMessage will be replaced with the attribute name.
+__errorMessage__ {String} - An optional string where you can specify a custom error message. 
+- **_:attribute_** inside errorMessage will be replaced with the attribute name.
+- **_:inputValue_** inside errorMessage will be replaced with the attribute value passed. If input value is a `Object({})` it will be coalesced to _"[Object]"_.
 
 ```js
 Validator.register('telephone', function(value, requirement, attribute) { // requirement parameter defaults to null

--- a/spec/input-value-access.js
+++ b/spec/input-value-access.js
@@ -1,0 +1,91 @@
+const { Validator, expect } = require("./setup.js");
+
+describe("access input value", function() {
+  it("should pass if value is not null", function() {
+    const validator = new Validator({}, { value: "string" });
+    expect(validator.fails()).to.be.false;
+    expect(validator.passes()).to.be.true;
+  });
+
+  it("should fail if value is null and not a string", function() {
+    const validator = new Validator(
+      { value: 12 },
+      { value: "required|string" }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+  });
+
+  it("should pass if value is replaced in the template error with :inputValue", function() {
+    const validator = new Validator(
+      { value: 12 },
+      { value: "required|in:val1,val2" },
+      { "in.value": "The value ':inputValue' is not a valid value." }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.get("value"));
+    expect(validator.errors.get("value")[0]).equal(
+      "The value '12' is not a valid value."
+    );
+  });
+
+  it("should pass if array is replaced in the template error with :inputValue", function() {
+    const validator = new Validator(
+      { value: [12, '13'] },
+      { value: "required|in:val1,val2" },
+      { "in.value": "The value ':inputValue' is not a valid value." }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.get("value"));
+    expect(validator.errors.get("value")[0]).equal(
+      "The value '12,13' is not a valid value."
+    );
+  });
+
+  
+  it("should pass if empty array is replaced in the template error with :inputValue", function() {
+    const validator = new Validator(
+      { value: [] },
+      { value: "string" },
+      { "string.value": "The value ':inputValue' is not a valid string." }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.get("value"));
+    expect(validator.errors.get("value")[0]).equal(
+      "The value '' is not a valid string."
+    );
+  });
+
+  
+  it("should pass if empty object '{}' is replaced for [Object]", function() {
+    const validator = new Validator(
+      { value: {} },
+      { value: "string" },
+      { "string.value": "The value ':inputValue' is not a valid string." }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.get("value"));
+    expect(validator.errors.get("value")[0]).equal(
+      "The value '[Object]' is not a valid string."
+    );
+  });
+
+  it("should pass if null is replaced for null text", function() {
+    const validator = new Validator(
+      { value: null },
+      { value: "required|string|same:34" },
+      { "required.value": "The value ':inputValue' is not a valid string." }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    console.log(validator.errors.get("value"));
+    expect(validator.errors.get("value"));
+    expect(validator.errors.get("value")[0]).equal(
+      "The value 'null' is not a valid string."
+    );
+  });
+});

--- a/src/messages.js
+++ b/src/messages.js
@@ -134,13 +134,17 @@ Messages.prototype = {
     var message, attribute;
 
     data.attribute = this._getAttributeName(rule.attribute);
+    data.inputValue = rule.inputValue;
     data[rule.name] = data[rule.name] || rule.getParameters().join(',');
 
     if (typeof template === 'string' && typeof data === 'object') {
       message = template;
 
       for (attribute in data) {
-        message = message.replace(new RegExp(':' + attribute, 'g'), data[attribute]);
+        const attrValue = data[attribute];
+        message = message.replace(new RegExp(':' + attribute, 'g'), 
+          !!attrValue && attrValue.constructor === Object ? '[Object]' : attrValue
+        );
       }
     }
 


### PR DESCRIPTION
# Feat Error Template Message

## Overview
The goal of this PR is to allow access of the input value on the error messages template strings via a `:inputValue` keyword.

## Use Case

A use case where user is making upload of an excel file with 100+ rows, and the validation of those fields throw an validation error just saying to the user that an error occurred is not very helpful.

It would be better to return the actual values(s) that are invalid so the user can find the values and perform the fixes.

```js
const validation = new Validator(
    data,
    {
        array: 'required|array',
        'array.*.postalCode': 'required|postal_code',
        // rest of validation schema...
    },
    {
        'postal_code.array.*.postalCode': "The postal code ':inputValue' is not valid.",
    }
);

// output -> "The postal code '0O987' is not valid."  | Second character is a letter 'O'
```

## Proposed implementation

Modify the `Messages._replacePlaceholders(rule, template, data)` to add the `rule.inputValue` to the data object. By doing this it will not collide with the existing implementation of `:value` templater for the custom replacements.

### Object as input value
The default string representation of an `{}` is _[object Object]_. In order to make it more readable the behavior of the replacement will be to replace it for _[Object]_ only.

PS. It was also considered the option `{...}`. Open to feedback on this.

## Updated README.md

Updated the README to reflect the newly added feature.