### PR TITLE
fix numeric related rules (issue #413)

### DIFF
--- a/spec/digits-rule.js
+++ b/spec/digits-rule.js
@@ -1,14 +1,14 @@
 const { Validator, expect } = require("./setup.js");
 
-describe("digits rule", function() {
-  it("should be numeric and must have an exact length of 5", function() {
+describe("digits rule", function () {
+  it("should be numeric and must have an exact length of 5", function () {
     const validation = new Validator({ zip: "90989" }, { zip: "digits:5" });
 
     expect(validation.passes()).to.be.true;
     expect(validation.fails()).to.be.false;
   });
 
-  it("should not pass if non-digits are present", function() {
+  it("should not pass if non-digits are present", function () {
     const validation = new Validator({ zip: "9098a" }, { zip: "digits:5" });
 
     expect(validation.fails()).to.be.true;
@@ -16,7 +16,15 @@ describe("digits rule", function() {
     expect(validation.passes()).to.be.false;
   });
 
-  it('should not pass if spaces are present', function() {
+  it("should fail with an array value", function () {
+    const validation = new Validator({ zip: ["90989"] }, { zip: "digits:5" });
+
+    expect(validation.fails()).to.be.true;
+    expect(validation.errors.first("zip")).to.equal("The zip must be 5 digits.");
+    expect(validation.passes()).to.be.false;
+  });
+
+  it('should not pass if spaces are present', function () {
     var validation = new Validator({
       zip: '9098 '
     }, {

--- a/spec/integer-rule.js
+++ b/spec/integer-rule.js
@@ -1,13 +1,13 @@
 const { Validator, expect } = require("./setup.js");
 
-describe("integer pass rules", function() {
-  it("should pass if no value is entered", function() {
+describe("integer pass rules", function () {
+  it("should pass if no value is entered", function () {
     const validator = new Validator({}, { age: "integer" });
     expect(validator.fails()).to.be.false;
     expect(validator.passes()).to.be.true;
   });
 
-  it("should pass with an integer value", function() {
+  it("should pass with an integer value", function () {
     const validator = new Validator(
       {
         age: 18
@@ -20,7 +20,7 @@ describe("integer pass rules", function() {
     expect(validator.passes()).to.be.true;
   });
 
-  it("should pass with a string containing an integer value", function() {
+  it("should pass with a string containing an integer value", function () {
     const validator = new Validator(
       {
         age: "18"
@@ -33,7 +33,7 @@ describe("integer pass rules", function() {
     expect(validator.passes()).to.be.true;
   });
 
-  it("should pass with unsigned integer", function() {
+  it("should pass with unsigned integer", function () {
     const validator = new Validator(
       {
         num: -123
@@ -47,8 +47,8 @@ describe("integer pass rules", function() {
   });
 });
 
-describe("integer fail rules", function() {
-  it("should fail with a decimal value", function() {
+describe("integer fail rules", function () {
+  it("should fail with a decimal value", function () {
     const validator = new Validator(
       {
         age: 18.9
@@ -62,7 +62,7 @@ describe("integer fail rules", function() {
     expect(validator.errors.first("age")).to.equal("The age must be an integer.");
   });
 
-  it("should fail with a string value containing numbers and letters", function() {
+  it("should fail with a string value containing numbers and letters", function () {
     const validator = new Validator(
       {
         age: "18d"
@@ -76,7 +76,7 @@ describe("integer fail rules", function() {
     expect(validator.errors.first("age")).to.equal("The age must be an integer.");
   });
 
-  it("should fail with a boolean true value", function() {
+  it("should fail with a boolean true value", function () {
     const validator = new Validator(
       {
         age: true
@@ -89,7 +89,7 @@ describe("integer fail rules", function() {
     expect(validator.passes()).to.be.false;
   });
 
-  it("should fail with a boolean false value", function() {
+  it("should fail with a boolean false value", function () {
     const validator = new Validator(
       {
         age: false
@@ -102,7 +102,7 @@ describe("integer fail rules", function() {
     expect(validator.passes()).to.be.false;
   });
 
-  it("should fail if the value is an array", function() {
+  it("should fail if the value is an array", function () {
     const validator = new Validator(
       {
         age: []
@@ -115,7 +115,20 @@ describe("integer fail rules", function() {
     expect(validator.passes()).to.be.false;
   });
 
-  it("should fail if the value is an object", function() {
+  it("should fail if the value is an array with one integer value", function () {
+    const validator = new Validator(
+      {
+        age: [7]
+      },
+      {
+        age: "required|integer"
+      }
+    );
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+  });
+
+  it("should fail if the value is an object", function () {
     const validator = new Validator(
       {
         age: {}
@@ -128,7 +141,7 @@ describe("integer fail rules", function() {
     expect(validator.passes()).to.be.false;
   });
 
-  it("should fail with unsigned float-integer", function() {
+  it("should fail with unsigned float-integer", function () {
     const validator = new Validator(
       {
         num: -70.36

--- a/spec/numeric-rule.js
+++ b/spec/numeric-rule.js
@@ -1,37 +1,43 @@
 const { Validator, expect } = require("./setup.js");
 
-describe("numeric validation rule", function() {
-  it("should pass with a numeric value", function() {
+describe("numeric validation rule", function () {
+  it("should pass with a numeric value", function () {
     const validator = new Validator({ age: 44 }, { age: "numeric" });
     expect(validator.passes()).to.be.true;
   });
 
-  it("should pass with a decimal numeric value", function() {
+  it("should pass with a decimal numeric value", function () {
     const validator = new Validator({ measurement: 0.5454 }, { measurement: "numeric" });
     expect(validator.passes()).to.be.true;
   });
 
-  it("should pass with a string numeric value", function() {
+  it("should pass with a string numeric value", function () {
     const validator = new Validator({ age: "44" }, { age: "numeric" });
     expect(validator.passes()).to.be.true;
   });
 
-  it("should pass with a string decimal numeric value", function() {
+  it("should pass with a string decimal numeric value", function () {
     const validator = new Validator({ measurement: "0.5454" }, { measurement: "numeric" });
     expect(validator.passes()).to.be.true;
   });
 
-  it("should fail with a string value", function() {
+  it("should fail with a string value", function () {
     const validator = new Validator({ age: "18something" }, { age: "numeric" });
     expect(validator.fails()).to.be.true;
   });
 
-  it("should fail with a boolean true value", function() {
+  it("should fail with an array value", function () {
+    const validator = new Validator({ age: [13] }, { age: "numeric" });
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+  });
+
+  it("should fail with a boolean true value", function () {
     const validator = new Validator({ age: true }, { age: "numeric" });
     expect(validator.fails()).to.be.true;
   });
 
-  it("should fail with a boolean false value", function() {
+  it("should fail with a boolean false value", function () {
     const validator = new Validator(
       {
         age: false
@@ -43,7 +49,7 @@ describe("numeric validation rule", function() {
     expect(validator.fails()).to.be.true;
   });
 
-  it("should pass with no value", function() {
+  it("should pass with no value", function () {
     const validator = new Validator(
       {},
       {
@@ -54,7 +60,7 @@ describe("numeric validation rule", function() {
     expect(validator.fails()).to.be.false;
   });
 
-  it("should pass with an empty string value", function() {
+  it("should pass with an empty string value", function () {
     const validator = new Validator({ age: "" }, { age: "numeric" });
     expect(validator.passes()).to.be.true;
     expect(validator.fails()).to.be.false;

--- a/src/rules.js
+++ b/src/rules.js
@@ -245,7 +245,7 @@ var rules = {
 
     num = Number(val); // tries to convert value to a number. useful if value is coming from form element
 
-    if (typeof num === "number" && !isNaN(num) && typeof val !== "boolean") {
+    if (typeof num === "number" && !isNaN(num) && typeof val !== "boolean" && !Array.isArray(val)) {
       return true;
     } else {
       return false;
@@ -368,7 +368,7 @@ var rules = {
   },
 
   integer: function (val) {
-    return String(parseInt(val, 10)) === String(val);
+    return !Array.isArray(val) && String(parseInt(val, 10)) === String(val);
   },
 
   digits: function (val, req) {


### PR DESCRIPTION
I've code this fix to solve this issue ( #413 ), checking if the value passed is not an Array in the `integer`, `digits` and `numeric` rules. And I've added another tests to cover this behavior too.