### PR TITLE
[WIP] add rule for alphabetic characters, as well as space.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ The field under validation may have alpha-numeric characters, as well as dashes 
 
 The field under validation must be entirely alpha-numeric characters.
 
+#### alpha_space
+
+The field under validation may have alphabetic characters, as well as space.
+
 #### array
 
 The field under validation must be an array.

--- a/spec/alpha_space-rule.js
+++ b/spec/alpha_space-rule.js
@@ -1,0 +1,32 @@
+const { Validator, expect } = require("./setup.js");
+
+describe("alpha_space validation rule", function() {
+  it("should fail with non alphabetic-space characters", function() {
+    const validator = new Validator({ name: "Daniel_." }, { name: "alpha_space" });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+  });
+
+  it("should fail with non-alphabetic characters", function() {
+    const validator = new Validator({ name: 12 }, { name: "alpha_space" });
+    expect(validator.fails()).to.be.false;
+    expect(validator.passes()).to.be.true;
+  });
+
+  it("should pass with only alphabetic-space characters", function() {
+    const validator = new Validator({ name: "Daniel Naranjo" }, { name: "alpha_space" });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
+  it("should pass when the field is blank / optional", function() {
+    const validator = new Validator({ name: "" }, { name: "alpha_space" });
+    expect(validator.passes()).to.be.true;
+  });
+
+  it("should pass when the field does not exist", function() {
+    const validator = new Validator({}, { name: "alpha_space" });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+});

--- a/spec/alpha_space-rule.js
+++ b/spec/alpha_space-rule.js
@@ -3,23 +3,23 @@ const { Validator, expect } = require("./setup.js");
 describe("alpha_space validation rule", function() {
   it("should fail with non alphabetic-space characters", function() {
     const validator = new Validator({ name: "Daniel_." }, { name: "alpha_space" });
-    expect(validator.passes()).to.be.false;
     expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
   });
 
   it("should fail with non-alphabetic characters", function() {
     const validator = new Validator({ name: 12 }, { name: "alpha_space" });
-    expect(validator.fails()).to.be.false;
-    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
   });
 
   it("should pass with only alphabetic-space characters", function() {
     const validator = new Validator({ name: "Daniel Naranjo" }, { name: "alpha_space" });
-    expect(validator.passes()).to.be.true;
     expect(validator.fails()).to.be.false;
+    expect(validator.passes()).to.be.true;
   });
 
-  it("should pass when the field is blank / optional", function() {
+  it("should pass when the field is an empty string", function() {
     const validator = new Validator({ name: "" }, { name: "alpha_space" });
     expect(validator.passes()).to.be.true;
   });

--- a/spec/error-messages.js
+++ b/spec/error-messages.js
@@ -77,6 +77,14 @@ describe("Error messages", function() {
       );
     });
 
+    it("should fail with non alpha space characters", function() {
+      const validator = new Validator({ name: "Daniel ." }, { name: "alpha_space" });
+      expect(validator.passes()).to.be.false;
+      expect(validator.errors.first("name")).to.equal(
+        "The name field may only contain alphabetic characters, as well as space."
+      );
+    });
+
     it("should fail without a matching confirmation field for the field under validation", function() {
       const validator = new Validator({ password: "abc" }, { password: "confirmed" });
       expect(validator.passes()).to.be.false;

--- a/src/rules.js
+++ b/src/rules.js
@@ -272,6 +272,10 @@ var rules = {
     return /^[a-zA-Z0-9]+$/.test(val);
   },
 
+  alpha_space: function (val) {
+    return /^[a-zA-Z ]+$/.test(val);
+  },
+
   same: function (val, req) {
     var val1 = this.validator._flattenObject(this.validator.input)[req];
     var val2 = val;


### PR DESCRIPTION
Hi, :sunglasses: 

I'm create this for cases like text validations as open fields, the alpha rule is insufficient for me, it can be solved with a custom rule obviously, but being such a common case in fields like description or names, I decided to add this rule because I suppose that many people you can use it to get it ready.

This is still in development - missing full test :computer: 

_any comments are welcome_