### PR TITLE
✨ `validated()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,66 @@ validator.checkAsync(passes, fails);
 
 ```
 
+### Working with validated input
+
+Use `validated()` method to retrieve only the validated data and to filter out attributes not found on rules provided.
+
+```js
+let validation = new Validator({
+  name: 'John',
+  email: 'johndoe@gmail.com',
+  age: 28,
+  gender: 'male'
+}, {
+  name: 'required',
+  age: 'min:18'
+});
+
+validation.validated(); // will return `{ "name": "John", "age": 28 }`
+```
+
+`validated()` method will thrown an error when current validation is failing.
+
+```js
+let validation = new Validator({
+  name: 'John',
+  email: 'johndoe@gmail.com',
+  age: 28,
+  gender: 'male'
+}, {
+  name: 'required',
+  age: 'min:40'
+});
+
+validation.validated(); // will throw `Error('Validation failed!')`
+```
+
+`validated()` method also works with asynchronous validation. In this case,
+`passes()` callback will receive only the validated data (without the
+attributes not found on rules provided) as the first argument.
+
+```js
+let validation = new Validator({
+  name: 'John',
+  email: 'johndoe@gmail.com',
+  age: 28,
+  gender: 'male'
+}, {
+  name: 'required|some_async_rule',
+  age: 'min:18'
+});
+
+function passes(validated) {
+  console.log(validated); // will output `{ "name": "John", "age": 28 }` if `some_async_rule` validates `'John'`
+}
+
+function fails() {
+  // will be called if `some_async_rule` does not validate `'John'`
+}
+
+validation.validated(passes, fails);
+```
+
 ### Error Messages
 
 This constructor will automatically generate error messages for validation rules that failed.

--- a/spec/validated.js
+++ b/spec/validated.js
@@ -5,24 +5,51 @@ describe("_onlyInputWithRules()", function () {
     const validator = new Validator(
       {
         email: "test1@example.com",
+        addresses: [
+          {
+            line1: "934 High Noon St. Ronkonkoma, NY 1177",
+            zip: 1177,
+          },
+          {
+            line1: "476 Main St. Clinton Township",
+            line2: "MI 48035",
+            zip: 48035,
+          },
+        ],
         additional_field1: "lorem_ipsum",
         additional_field2: "lorem_ipsum",
       },
       {
         email: "required|string|email",
+        "addresses.*.line1": "required|string|max:200",
+        "addresses.*.line2": "nullable|string|max:200",
       }
     );
 
-    expect(validator._onlyInputWithRules()).to.eql({
+    const validated = validator._onlyInputWithRules();
+
+    expect(validated).to.eql({
       email: "test1@example.com",
+      addresses: [
+        {
+          line1: "934 High Noon St. Ronkonkoma, NY 1177",
+        },
+        {
+          line1: "476 Main St. Clinton Township",
+          line2: "MI 48035",
+        },
+      ],
     });
-    expect(validator._onlyInputWithRules()).to.have.property("email");
-    expect(validator._onlyInputWithRules()).not.to.have.property(
-      "additional_field1"
-    );
-    expect(validator._onlyInputWithRules()).not.to.have.property(
-      "additional_field2"
-    );
+    expect(validated).to.have.property("email");
+    expect(validated).to.have.property("addresses");
+    expect(validated).not.to.have.property("additional_field1");
+    expect(validated).not.to.have.property("additional_field2");
+    expect(validated.addresses[0]).to.have.property("line1");
+    expect(validated.addresses[0]).not.to.have.property("line2");
+    expect(validated.addresses[0]).not.to.have.property("zip");
+    expect(validated.addresses[1]).to.have.property("line1");
+    expect(validated.addresses[1]).to.have.property("line2");
+    expect(validated.addresses[1]).not.to.have.property("zip");
   });
 });
 
@@ -33,50 +60,47 @@ describe("validated()", function () {
       function (username, attribute, req, passes) {
         setTimeout(function () {
           if (username === "dustin") {
-            passes(false, "The :attribute can not be Dustin.");
+            passes(false);
           } else {
             passes();
           }
         }, 1000);
-      }
+      },
+      "The :attribute can not be Dustin."
     );
   });
 
   it("should return only attributes defined in the rules (normal)", function () {
     const validator = new Validator(
       {
-        user: "dustin_the_second",
+        user: "John Doe",
         additional_field1: "lorem_ipsum",
         additional_field2: "lorem_ipsum",
       },
-      {
-        user: "required|string",
-      }
+      { user: "string" }
     );
 
-    expect(validator.validated()).to.eql({
-      user: "dustin_the_second",
-    });
-    expect(validator.validated()).to.have.property("user");
-    expect(validator.validated()).not.to.have.property("additional_field1");
-    expect(validator.validated()).not.to.have.property("additional_field2");
+    const validated = validator.validated();
+
+    expect(validated).to.eql({ user: "John Doe" });
+    expect(validated).to.have.property("user");
+    expect(validated).not.to.have.property("additional_field1");
+    expect(validated).not.to.have.property("additional_field2");
   });
 
   it("should return only attributes defined in the rules (async)", function (done) {
     const validator = new Validator(
       {
-        user: "dustin_the_second",
+        user: "John Doe",
         additional_field1: "lorem_ipsum",
         additional_field2: "lorem_ipsum",
       },
-      {
-        user: "required|string|not_dustin",
-      }
+      { user: "not_dustin" }
     );
 
     validator.validated(
       function (validated) {
-        expect(validated).to.eql({ user: "dustin_the_second" });
+        expect(validated).to.eql({ user: "John Doe" });
         expect(validated).to.have.property("user");
         expect(validated).not.to.have.property("additional_field1");
         expect(validated).not.to.have.property("additional_field2");
@@ -89,37 +113,22 @@ describe("validated()", function () {
   });
 
   it("should throw an Error when current validation fails (normal)", function () {
-    const validator = new Validator(
-      {
-        user: "dustin_the_second",
-        additional_field1: "lorem_ipsum",
-        additional_field2: "lorem_ipsum",
-      },
-      {
-        user: "required|string|max:10",
-      }
-    );
+    const validator = new Validator({ user: "John Doe" }, { user: "min:20" });
 
     expect(validator.validated.bind(validator)).to.throw("Validation failed!");
   });
 
   it("should throw an Error when current validation fails (async)", function (done) {
-    const validator = new Validator(
-      {
-        user: "dustin",
-        additional_field1: "lorem_ipsum",
-        additional_field2: "lorem_ipsum",
-      },
-      {
-        user: "required|string|not_dustin",
-      }
-    );
+    const validator = new Validator({ user: "dustin" }, { user: "not_dustin" });
 
     validator.validated(
       function (validated) {
         throw new Error("passes callback shouldn't be called!");
       },
       function () {
+        expect(validator.errors.first("user")).to.be.equal(
+          "The user can not be Dustin."
+        );
         done();
       }
     );

--- a/spec/validated.js
+++ b/spec/validated.js
@@ -1,0 +1,127 @@
+const { Validator, expect } = require("./setup.js");
+
+describe("_onlyInputWithRules()", function () {
+  it("should return only attributes defined in the rules", function () {
+    const validator = new Validator(
+      {
+        email: "test1@example.com",
+        additional_field1: "lorem_ipsum",
+        additional_field2: "lorem_ipsum",
+      },
+      {
+        email: "required|string|email",
+      }
+    );
+
+    expect(validator._onlyInputWithRules()).to.eql({
+      email: "test1@example.com",
+    });
+    expect(validator._onlyInputWithRules()).to.have.property("email");
+    expect(validator._onlyInputWithRules()).not.to.have.property(
+      "additional_field1"
+    );
+    expect(validator._onlyInputWithRules()).not.to.have.property(
+      "additional_field2"
+    );
+  });
+});
+
+describe("validated()", function () {
+  this.beforeAll(function () {
+    Validator.registerAsync(
+      "not_dustin",
+      function (username, attribute, req, passes) {
+        setTimeout(function () {
+          if (username === "dustin") {
+            passes(false, "The :attribute can not be Dustin.");
+          } else {
+            passes();
+          }
+        }, 1000);
+      }
+    );
+  });
+
+  it("should return only attributes defined in the rules (normal)", function () {
+    const validator = new Validator(
+      {
+        user: "dustin_the_second",
+        additional_field1: "lorem_ipsum",
+        additional_field2: "lorem_ipsum",
+      },
+      {
+        user: "required|string",
+      }
+    );
+
+    expect(validator.validated()).to.eql({
+      user: "dustin_the_second",
+    });
+    expect(validator.validated()).to.have.property("user");
+    expect(validator.validated()).not.to.have.property("additional_field1");
+    expect(validator.validated()).not.to.have.property("additional_field2");
+  });
+
+  it("should return only attributes defined in the rules (async)", function (done) {
+    const validator = new Validator(
+      {
+        user: "dustin_the_second",
+        additional_field1: "lorem_ipsum",
+        additional_field2: "lorem_ipsum",
+      },
+      {
+        user: "required|string|not_dustin",
+      }
+    );
+
+    validator.validated(
+      function (validated) {
+        expect(validated).to.eql({ user: "dustin_the_second" });
+        expect(validated).to.have.property("user");
+        expect(validated).not.to.have.property("additional_field1");
+        expect(validated).not.to.have.property("additional_field2");
+        done();
+      },
+      function () {
+        throw new Error("fails callback shouldn't be called!");
+      }
+    );
+  });
+
+  it("should throw an Error when current validation fails (normal)", function () {
+    const validator = new Validator(
+      {
+        user: "dustin_the_second",
+        additional_field1: "lorem_ipsum",
+        additional_field2: "lorem_ipsum",
+      },
+      {
+        user: "required|string|max:10",
+      }
+    );
+
+    expect(validator.validated.bind(validator)).to.throw("Validation failed!");
+  });
+
+  it("should throw an Error when current validation fails (async)", function (done) {
+    const validator = new Validator(
+      {
+        user: "dustin",
+        additional_field1: "lorem_ipsum",
+        additional_field2: "lorem_ipsum",
+      },
+      {
+        user: "required|string|not_dustin",
+      }
+    );
+
+    validator.validated(
+      function (validated) {
+        throw new Error("passes callback shouldn't be called!");
+      },
+      function () {
+        done();
+      }
+    );
+  });
+});

--- a/src/validator.js
+++ b/src/validator.js
@@ -525,6 +525,47 @@ Validator.prototype = {
     }
 
     return this.hasAsync || hasCallback;
+  },
+
+  /**
+   * Get the attributes and values that were validated.
+   *
+   * @param {function} passes
+   * @param {function} fails
+   * @return {object|undefined}
+   */
+  validated: function (passes, fails) {
+    if (this._checkAsync('passes', passes)) {
+      return this.checkAsync(
+        function () {
+          passes(this._onlyInputWithRules());
+        }.bind(this),
+        fails
+      );
+    } else {
+      if (this.check()) {
+        return this._onlyInputWithRules();
+      } else {
+        throw new Error('Validation failed!');
+      }
+    }
+  },
+
+  /**
+   * Filter input only the keys defined in the rules.
+   * 
+   * @returns {object}
+   */
+  _onlyInputWithRules: function () {
+    var newObj = { };
+  
+    Object.keys(this.input).forEach((key) => {
+      if (this.input[key] !== undefined && Object.keys(this.rules).includes(key)) {
+        newObj[key] = this.input[key];
+      }
+    });
+
+    return newObj;
   }
 
 };

--- a/src/validator.js
+++ b/src/validator.js
@@ -554,18 +554,25 @@ Validator.prototype = {
   /**
    * Filter input only the keys defined in the rules.
    * 
+   * @param {any} obj
+   * @param {string} keyPrefix
    * @returns {object}
    */
-  _onlyInputWithRules: function () {
-    var newObj = { };
-  
-    Object.keys(this.input).forEach((key) => {
-      if (this.input[key] !== undefined && Object.keys(this.rules).includes(key)) {
-        newObj[key] = this.input[key];
+  _onlyInputWithRules: function (obj, keyPrefix) {
+    var prefix = keyPrefix === undefined ? '' : keyPrefix;
+    var values = JSON.parse(JSON.stringify(obj === undefined ? this.input : obj));
+
+    Object.keys(values).forEach((key) => {
+      if (values[key] !== null && typeof values[key] === 'object') {
+        values[key] = this._onlyInputWithRules(values[key], prefix + key + '.');
+      } else {
+        if (values[key] === undefined || !Object.keys(this.rules).includes(prefix + key)) {
+          delete values[key];
+        }
       }
     });
 
-    return newObj;
+    return values;
   }
 
 };


### PR DESCRIPTION
# ✨ `validated()` method

Fixes #307 

## Description

This PR adds two methods to `Validator`'s prototype; `validated()` and `_onlyInputWithRules()`. Inspired from [Laravel's validation concepts](https://laravel.com/docs/8.x/validation#working-with-validated-input).

`validated()` method will retrieve the input data without the attributes not defined in rules provided. This helps to extract only valid dataset from input and filter out unnecessary or additional attributes from input.

While `validated()` throws an error if the validation fails, `_onlyInputWithRules()` does the pure job to filter out non-listed-in-rules attributes. `validated()` method relies on `_onyInputWithRules()` method under the hood.

## Type of change

- [x] Documentation update
- [x] New feature

