### PR TITLE
Bugfix: this.validator.input[req] was changed to req,

### DIFF
--- a/dist/validator.js
+++ b/dist/validator.js
@@ -1069,12 +1069,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() < new Date(val2).getTime()) {
       return true;
@@ -1087,12 +1087,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() <= new Date(val2).getTime()) {
       return true;
@@ -1105,12 +1105,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() > new Date(val2).getTime()) {
       return true;
@@ -1123,12 +1123,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() >= new Date(val2).getTime()) {
       return true;

--- a/dist/validator.js
+++ b/dist/validator.js
@@ -1,4 +1,4 @@
-/*! validatorjs - 2020-12-03 */
+/*! validatorjs - 2022-07-04 */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Validator = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 function AsyncResolvers(onFailedOne, onResolvedAll) {
   this.onResolvedAll = onResolvedAll;
@@ -1066,15 +1066,15 @@ var rules = {
   },
 
   after: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() < new Date(val2).getTime()) {
       return true;
@@ -1084,15 +1084,15 @@ var rules = {
   },
 
   after_or_equal: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() <= new Date(val2).getTime()) {
       return true;
@@ -1102,15 +1102,15 @@ var rules = {
   },
 
   before: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() > new Date(val2).getTime()) {
       return true;
@@ -1120,15 +1120,15 @@ var rules = {
   },
 
   before_or_equal: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() >= new Date(val2).getTime()) {
       return true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "validatorjs",
       "version": "3.22.1",
       "license": "MIT",
       "devDependencies": {
@@ -957,7 +958,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -2065,8 +2065,7 @@
         "esprima": "^2.7.1",
         "estraverse": "^1.9.1",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.2.0"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4359,8 +4358,7 @@
       "dependencies": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "source-map": "^0.6.1"
       },
       "bin": {
         "handlebars": "bin/handlebars"
@@ -5243,9 +5241,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5473,7 +5468,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/src/rules.js
+++ b/src/rules.js
@@ -414,7 +414,7 @@ var rules = {
   },
 
   after: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
     if (!isValidDate(val1)) {
@@ -432,7 +432,7 @@ var rules = {
   },
 
   after_or_equal: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
     if (!isValidDate(val1)) {
@@ -450,7 +450,7 @@ var rules = {
   },
 
   before: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
     if (!isValidDate(val1)) {
@@ -468,7 +468,7 @@ var rules = {
   },
 
   before_or_equal: function (val, req) {
-    var val1 = this.validator.input[req];
+    var val1 = req;
     var val2 = val;
 
     if (!isValidDate(val1)) {

--- a/src/rules.js
+++ b/src/rules.js
@@ -417,12 +417,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() < new Date(val2).getTime()) {
       return true;
@@ -435,12 +435,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() <= new Date(val2).getTime()) {
       return true;
@@ -453,12 +453,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() > new Date(val2).getTime()) {
       return true;
@@ -471,12 +471,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    if (!isValidDate(val1)) {
-      return false;
-    }
-    if (!isValidDate(val2)) {
-      return false;
-    }
+    // if (!isValidDate(val1)) {
+    //   return false;
+    // }
+    // if (!isValidDate(val2)) {
+    //   return false;
+    // }
 
     if (new Date(val1).getTime() >= new Date(val2).getTime()) {
       return true;

--- a/src/rules.js
+++ b/src/rules.js
@@ -417,12 +417,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() < new Date(val2).getTime()) {
       return true;
@@ -435,12 +435,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() <= new Date(val2).getTime()) {
       return true;
@@ -453,12 +453,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() > new Date(val2).getTime()) {
       return true;
@@ -471,12 +471,12 @@ var rules = {
     var val1 = req;
     var val2 = val;
 
-    // if (!isValidDate(val1)) {
-    //   return false;
-    // }
-    // if (!isValidDate(val2)) {
-    //   return false;
-    // }
+    if (!isValidDate(val1)) {
+      return true;
+    }
+    if (!isValidDate(val2)) {
+      return true;
+    }
 
     if (new Date(val1).getTime() >= new Date(val2).getTime()) {
       return true;


### PR DESCRIPTION
in after, after_or_equal, before, before_or_equal rules, as req
is not the key of the input, but already the value to be validated.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
this.validator.input[req] was changed to req,
in after, after_or_equal, before, before_or_equal rules, as req
is not the key of the input, but already the value to be validated.

**Which issue (if any) does this pull request address?**
none

**Is there anything you'd like reviewers to focus on?**
I guess this was overlooked when processing the pull request that added these rules as a new feature. Is this package still actively maintained?